### PR TITLE
NewAPIRequest function to avoid repetitive HTTP request code

### DIFF
--- a/add.go
+++ b/add.go
@@ -27,17 +27,9 @@ func (c *Client) Add(ctx context.Context, URLs []URL, bypassSeencheck bool) (err
 	}
 
 	// build request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URLsEndpoint.String(), bytes.NewReader(jsonPayload))
+	req, err := NewAPIRequest(c, ctx, http.MethodPost, c.URLsEndpoint.String(), bytes.NewReader(jsonPayload))
 	if err != nil {
 		return err
-	}
-
-	req.Header.Add("X-Auth-Key", c.Key)
-	req.Header.Add("X-Auth-Secret", c.Secret)
-	req.Header.Add("User-Agent", "gocrawlhq/"+Version)
-
-	if c.Identifier != "" {
-		req.Header.Add("X-Identifier", c.Identifier)
 	}
 
 	// execute request

--- a/delete.go
+++ b/delete.go
@@ -23,17 +23,9 @@ func (c *Client) Delete(ctx context.Context, URLs []URL, localCrawls int) (err e
 	}
 
 	// build request
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.URLsEndpoint.String(), bytes.NewReader(jsonPayload))
+	req, err := NewAPIRequest(c, ctx, http.MethodDelete, c.URLsEndpoint.String(), bytes.NewReader(jsonPayload))
 	if err != nil {
 		return err
-	}
-
-	req.Header.Add("X-Auth-Key", c.Key)
-	req.Header.Add("X-Auth-Secret", c.Secret)
-	req.Header.Add("User-Agent", "gocrawlhq/"+Version)
-
-	if c.Identifier != "" {
-		req.Header.Add("X-Identifier", c.Identifier)
 	}
 
 	// execute request

--- a/get_test.go
+++ b/get_test.go
@@ -1,0 +1,126 @@
+package gocrawlhq
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+func TestClient_Get_Success(t *testing.T) {
+	expectedKey := "test-key"
+	expectedSecret := "test-secret"
+	expectedIdentifier := "test-id"
+	expectedUserAgent := "gocrawlhq/" + Version
+	expectedSize := 2
+
+	mockURLs := []URL{
+		{Value: "https://example.com"},
+		{Value: "https://test.com"},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check method
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET, got %s", r.Method)
+		}
+		// Check headers
+		if r.Header.Get("X-Auth-Key") != expectedKey {
+			t.Error("Missing or incorrect X-Auth-Key")
+		}
+		if r.Header.Get("X-Auth-Secret") != expectedSecret {
+			t.Error("Missing or incorrect X-Auth-Secret")
+		}
+		if r.Header.Get("User-Agent") != expectedUserAgent {
+			t.Error("Missing or incorrect User-Agent")
+		}
+		if r.Header.Get("X-Identifier") != expectedIdentifier {
+			t.Error("Missing or incorrect X-Identifier")
+		}
+		// Check query param
+		if r.URL.Query().Get("size") != strconv.Itoa(expectedSize) {
+			t.Error("Missing or incorrect 'size' query param")
+		}
+		// Respond with mock data
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(mockURLs)
+	}))
+	defer ts.Close()
+
+	parsedURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	client := &Client{
+		Key:          expectedKey,
+		Secret:       expectedSecret,
+		Identifier:   expectedIdentifier,
+		URLsEndpoint: parsedURL,
+		HTTPClient:   http.DefaultClient,
+	}
+
+	urls, err := client.Get(context.Background(), expectedSize)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if len(urls) != expectedSize {
+		t.Errorf("Expected %d URLs, got %d", expectedSize, len(urls))
+	}
+	if urls[0].Value != mockURLs[0].Value {
+		t.Errorf("Unexpected URL[0]: %v", urls[0])
+	}
+}
+
+func TestClient_Get_Empty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent) // 204
+	}))
+	defer ts.Close()
+
+	parsedURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	client := &Client{
+		Key:          "k",
+		Secret:       "s",
+		URLsEndpoint: parsedURL,
+		HTTPClient:   http.DefaultClient,
+	}
+
+	_, err = client.Get(context.Background(), 5)
+	if !errors.Is(err, ErrFeedEmpty) {
+		t.Errorf("Expected feed empty error, got: %v", err)
+	}
+}
+
+func TestClient_Get_Non200(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError) // 500
+	}))
+	defer ts.Close()
+
+	parsedURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	client := &Client{
+		Key:          "k",
+		Secret:       "s",
+		URLsEndpoint: parsedURL,
+		HTTPClient:   http.DefaultClient,
+	}
+
+	_, err = client.Get(context.Background(), 5)
+	if err == nil || err.Error() != "non-200 status code: 500" {
+		t.Errorf("Expected status code error, got: %v", err)
+	}
+}

--- a/gocrawlhq.go
+++ b/gocrawlhq.go
@@ -1,6 +1,8 @@
 package gocrawlhq
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -72,4 +74,19 @@ func Init(key, secret, project, address, identifier string, timeout int) (c *Cli
 	c.ProjectEndpoint.Path = path.Join(c.ProjectEndpoint.Path, "api", "projects", c.Project)
 
 	return c, nil
+}
+
+func NewAPIRequest(c *Client, ctx context.Context, method string, url string, body io.Reader) (*http.Request, error) {
+	// Create base request
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("X-Auth-Key", c.Key)
+	req.Header.Add("X-Auth-Secret", c.Secret)
+	req.Header.Add("User-Agent", "gocrawlhq/"+Version)
+	if c.Identifier != "" {
+		req.Header.Add("X-Identifier", c.Identifier)
+	}
+	return req, nil
 }

--- a/project.go
+++ b/project.go
@@ -23,17 +23,9 @@ type Project struct {
 func (c *Client) GetProject(ctx context.Context) (p *Project, err error) {
 	expectedStatusCodes := 200
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.ProjectEndpoint.String(), nil)
+	req, err := NewAPIRequest(c, ctx, http.MethodGet, c.ProjectEndpoint.String(), nil)
 	if err != nil {
 		return p, err
-	}
-
-	req.Header.Add("X-Auth-Key", c.Key)
-	req.Header.Add("X-Auth-Secret", c.Secret)
-	req.Header.Add("User-Agent", "gocrawlhq/"+Version)
-
-	if c.Identifier != "" {
-		req.Header.Add("X-Identifier", c.Identifier)
 	}
 
 	resp, err := c.HTTPClient.Do(req)

--- a/reset.go
+++ b/reset.go
@@ -9,17 +9,9 @@ import (
 func (c *Client) Reset(ctx context.Context) (err error) {
 	expectedStatusCode := 202
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.ResetEndpoint.String(), nil)
+	req, err := NewAPIRequest(c, ctx, http.MethodPost, c.ResetEndpoint.String(), nil)
 	if err != nil {
 		return err
-	}
-
-	req.Header.Add("X-Auth-Key", c.Key)
-	req.Header.Add("X-Auth-Secret", c.Secret)
-	req.Header.Add("User-Agent", "gocrawlhq/"+Version)
-
-	if c.Identifier != "" {
-		req.Header.Add("X-Identifier", c.Identifier)
 	}
 
 	resp, err := c.HTTPClient.Do(req)
@@ -38,17 +30,9 @@ func (c *Client) Reset(ctx context.Context) (err error) {
 func (c *Client) ResetURL(ctx context.Context, ID string) (err error) {
 	expectedStatusCode := 200
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.ResetEndpoint.String()+"/"+ID, nil)
+	req, err := NewAPIRequest(c, ctx, http.MethodPost, c.ResetEndpoint.String()+"/"+ID, nil)
 	if err != nil {
 		return err
-	}
-
-	req.Header.Add("X-Auth-Key", c.Key)
-	req.Header.Add("X-Auth-Secret", c.Secret)
-	req.Header.Add("User-Agent", "gocrawlhq/"+Version)
-
-	if c.Identifier != "" {
-		req.Header.Add("X-Identifier", c.Identifier)
 	}
 
 	resp, err := c.HTTPClient.Do(req)

--- a/seencheck.go
+++ b/seencheck.go
@@ -14,17 +14,9 @@ func (c *Client) Seencheck(ctx context.Context, URLs []URL) (outputURLs []URL, e
 		return URLs, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.SeencheckEndpoint.String(), bytes.NewReader(jsonPayload))
+	req, err := NewAPIRequest(c, ctx, http.MethodPost, c.SeencheckEndpoint.String(), bytes.NewReader(jsonPayload))
 	if err != nil {
 		return URLs, err
-	}
-
-	req.Header.Add("X-Auth-Key", c.Key)
-	req.Header.Add("X-Auth-Secret", c.Secret)
-	req.Header.Add("User-Agent", "gocrawlhq/"+Version)
-
-	if c.Identifier != "" {
-		req.Header.Add("X-Identifier", c.Identifier)
 	}
 
 	resp, err := c.HTTPClient.Do(req)


### PR DESCRIPTION
Encapsulate `http.NewRequestWithContext` and add extra authentication headers in a single place. Replace repetitive code.

Add unit test for `Get`.