### PR TITLE
No longer throws `gocrawlhq: feed is empty` error

### DIFF
--- a/add.go
+++ b/add.go
@@ -9,8 +9,6 @@ import (
 )
 
 func (c *Client) Add(ctx context.Context, URLs []URL, bypassSeencheck bool) (err error) {
-	expectedStatusCode := 201
-
 	// build payload
 	var URLsPayload []URL
 
@@ -48,8 +46,8 @@ func (c *Client) Add(ctx context.Context, URLs []URL, bypassSeencheck bool) (err
 	defer resp.Body.Close()
 
 	// check response status code
-	if resp.StatusCode != expectedStatusCode {
-		return fmt.Errorf("non-%d status code: %d", expectedStatusCode, resp.StatusCode)
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 
 	return err

--- a/delete.go
+++ b/delete.go
@@ -9,8 +9,6 @@ import (
 )
 
 func (c *Client) Delete(ctx context.Context, URLs []URL, localCrawls int) (err error) {
-	expectedStatusCode := 204
-
 	// build payload
 	payload := DeletePayload{
 		LocalCrawls: localCrawls,
@@ -44,8 +42,8 @@ func (c *Client) Delete(ctx context.Context, URLs []URL, localCrawls int) (err e
 	defer resp.Body.Close()
 
 	// check response status code
-	if resp.StatusCode != expectedStatusCode {
-		return fmt.Errorf("non-%d status code: %d", expectedStatusCode, resp.StatusCode)
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 
 	return err

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,7 @@
+package gocrawlhq
+
+import (
+	"errors"
+)
+
+var ErrUnexpectedStatusCode = errors.New("unexpected status code")

--- a/get.go
+++ b/get.go
@@ -10,10 +10,6 @@ import (
 )
 
 func (c *Client) Get(ctx context.Context, size int) (URLs []URL, err error) {
-	expectedStatusCode := 200
-	emptyStatusCode := 204
-
-	// build request
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.URLsEndpoint.String(), nil)
 	if err != nil {
 		return URLs, err
@@ -39,13 +35,13 @@ func (c *Client) Get(ctx context.Context, size int) (URLs []URL, err error) {
 	defer resp.Body.Close()
 
 	// check response status code for 'empty' or 204
-	if resp.StatusCode == emptyStatusCode {
+	if resp.StatusCode == http.StatusNoContent {
 		return URLs, errors.New("gocrawlhq: feed is empty")
 	}
 
 	// check response status code for 200
-	if resp.StatusCode != expectedStatusCode {
-		return URLs, fmt.Errorf("non-%d status code: %d", expectedStatusCode, resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		return URLs, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 
 	// decode response body

--- a/get.go
+++ b/get.go
@@ -3,7 +3,6 @@ package gocrawlhq
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -36,7 +35,7 @@ func (c *Client) Get(ctx context.Context, size int) (URLs []URL, err error) {
 
 	// check response status code for 'empty' or 204
 	if resp.StatusCode == http.StatusNoContent {
-		return URLs, errors.New("gocrawlhq: feed is empty")
+		return URLs, nil
 	}
 
 	// check response status code for 200

--- a/reset.go
+++ b/reset.go
@@ -7,8 +7,6 @@ import (
 )
 
 func (c *Client) Reset(ctx context.Context) (err error) {
-	expectedStatusCode := 202
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.ResetEndpoint.String(), nil)
 	if err != nil {
 		return err
@@ -28,16 +26,14 @@ func (c *Client) Reset(ctx context.Context) (err error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != expectedStatusCode {
-		return fmt.Errorf("non-%d status code: %d", expectedStatusCode, resp.StatusCode)
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 
 	return nil
 }
 
 func (c *Client) ResetURL(ctx context.Context, ID string) (err error) {
-	expectedStatusCode := 200
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.ResetEndpoint.String()+"/"+ID, nil)
 	if err != nil {
 		return err
@@ -57,8 +53,8 @@ func (c *Client) ResetURL(ctx context.Context, ID string) (err error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != expectedStatusCode {
-		return fmt.Errorf("non-%d status code: %d", expectedStatusCode, resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 
 	return nil

--- a/seencheck.go
+++ b/seencheck.go
@@ -33,12 +33,12 @@ func (c *Client) Seencheck(ctx context.Context, URLs []URL) (outputURLs []URL, e
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 200 {
+	if resp.StatusCode == http.StatusOK {
 		err = json.NewDecoder(resp.Body).Decode(&outputURLs)
 		if err != nil {
 			return URLs, err
 		}
-	} else if resp.StatusCode != 204 {
+	} else if resp.StatusCode != http.StatusNoContent {
 		return URLs, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 

--- a/seencheck.go
+++ b/seencheck.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"net/http"
 )
 
@@ -39,7 +39,7 @@ func (c *Client) Seencheck(ctx context.Context, URLs []URL) (outputURLs []URL, e
 			return URLs, err
 		}
 	} else if resp.StatusCode != 204 {
-		return URLs, errors.New("unexpected status code: " + resp.Status)
+		return URLs, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 
 	return outputURLs, err


### PR DESCRIPTION
`gocrawlhq: feed is empty` is logically equivalent to `len(URLs) == 0 && err == nil` and should not be treated as a separate special error.

---

also introduced unified `UnexpectedStatusCode` error type.